### PR TITLE
Various stuff

### DIFF
--- a/module.json
+++ b/module.json
@@ -17,6 +17,7 @@
     "/module/cyphercombat.mjs"
   ],
   "scripts": [],
+  "socket": true,
   "styles": [
     "/styles/cyphercombat.css"
   ],

--- a/module/cyphercombat.mjs
+++ b/module/cyphercombat.mjs
@@ -1,8 +1,9 @@
+import { toggleHidden } from "./helpers/actor-actions.mjs";
 import { CypherCombatSidebar } from "./helpers/combat.mjs";
 import { registerHelpers } from "./helpers/handlebars.mjs";
 
 
-Hooks.once('init', () => {
+Hooks.on('init', () => {
 
     // Handlerbar Helpers
     registerHelpers.init();
@@ -10,6 +11,10 @@ Hooks.once('init', () => {
     // New combat tracker
     let combatCypher = new CypherCombatSidebar();
     combatCypher.startup();
+
+    game.socket.on('module.cyphercombat', (data) => {
+        if (data.operation === 'toggleHidden') toggleHidden(data.combatant);
+    });
 
 });
 

--- a/module/helpers/actor-actions.mjs
+++ b/module/helpers/actor-actions.mjs
@@ -1,0 +1,17 @@
+export function toggleHidden(combatant) {
+  combatant.update({ hidden: !combatant.hidden });
+};
+
+// Function to toggle defeated status
+export async function toggleDefeatedStatus(combatant) {
+  const isDefeated = !combatant.isDefeated;
+  await combatant.update({ defeated: isDefeated });
+  const token = combatant.token;
+  if (!token) return;
+  // Push the defeated status to the token
+  const status = CONFIG.statusEffects.find(e => e.id === CONFIG.Combat.defeatedStatusId);
+  if (!status && !token.object) return;
+  const effect = token.actor && status ? status : CONFIG.controlIcons.defeated;
+  if (token.object) await token.object.toggleEffect(effect, { overlay: true, active: isDefeated });
+  else await token.toggleActiveEffect(effect, { overlay: true, active: isDefeated });
+};

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -159,9 +159,6 @@ export class CypherCombatSidebar {
             } else {
               combatant.actor.update({ "data.damage.damageTrack": 'Debilitated' })
             }
-            if (combatant.isDefeated) {
-              toggleDefeatedStatus(combatant);
-            }
             break;
           case "markDead":
             if (combatant.actor.type == 'PC') {
@@ -170,8 +167,9 @@ export class CypherCombatSidebar {
               } else {
                 combatant.actor.update({ "data.damage.damageTrack": 'Dead' })
               }
+            } else if (combatant.actor.type != 'PC') {
+              toggleDefeatedStatus(combatant);
             }
-            toggleDefeatedStatus(combatant);
             break;
           // Roll combatant initiative
           case "rollInitiative":

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -250,7 +250,7 @@ export class CypherCombatSidebar {
         combatant.isObserver = (combatant.actor.permission == 2) ? true : false;
 
         // Determine if combatant is active
-        combatant.active = (combatant.data.tokenId == game.combat.combatant.data.tokenId) ? true : false;
+        combatant.active = (combatant.data.tokenId == game.combat.combatant.data.tokenId && game.combat.started) ? true : false;
       }
       // Append actors
       combatants.push(combatant)

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -245,7 +245,7 @@ export class CypherCombatSidebar {
         combatant.isObserver = (combatant.actor.permission == 2) ? true : false;
 
         // Determine if combatant is active
-        combatant.active = (combatant.data.actorId == game.combat.combatant.data.actorId) ? true : false;
+        combatant.active = (combatant.data.tokenId == game.combat.combatant.data.tokenId) ? true : false;
       }
       // Append actors
       combatants.push(combatant)

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -184,7 +184,7 @@ export class CypherCombatSidebar {
     });
 
     Hooks.on('updateToken', (scene, token, data, options, id) => {
-      if (data.actorData) {
+      if (data) {
         ui.combat.render();
       }
     });

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -10,7 +10,7 @@ export class CypherCombatSidebar {
       $('body').on('change', '.combat-input', (event) => {
         event.preventDefault();
 
-        // Get the incput and actor element.
+        // Get the input and actor element.
         const dataset = event.currentTarget.dataset;
         let $input = $(event.currentTarget);
         let $actorRow = $input.parents('.directory-item.actor-elem');
@@ -93,8 +93,13 @@ export class CypherCombatSidebar {
 
       const findToken = (event) => {
         const combatant = event.currentTarget;
-        const c = combatant.dataset.actorId;
-        token = canvas.tokens.placeables.find(t => t.data.actorId == c);
+        const c = combatant.dataset.combatantId;
+        for (let t of canvas.tokens.placeables) {
+          if (t.combatant) {
+            if (t.combatant.data._id == c) { token = t };
+          }
+        }
+
         return token;
       };
 

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -1,3 +1,5 @@
+import { toggleDefeatedStatus, toggleHidden } from "./actor-actions.mjs";
+
 export class CypherCombatSidebar {
   // This must be called in the `init` hook in order for the other hooks to ire correctly.
   startup() {
@@ -93,8 +95,8 @@ export class CypherCombatSidebar {
       $('body').on('mouseenter', '.combatant', (event) => {
         findToken(event);
         if (token.isOwner || game.user.isGM) {
-          if ( token?.isVisible ) {
-            if ( !token._controlled ) token._onHoverIn();
+          if (token?.isVisible) {
+            if (!token._controlled) token._onHoverIn();
           }
         }
       });
@@ -129,66 +131,51 @@ export class CypherCombatSidebar {
         }
       });
 
-      $('body').on('click', '.combatant-control', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const btn = e.currentTarget;
-        const combatant = btn.closest(".combatant");
-        const c = combatant.dataset.combatantId;
-        const actor = combatant.dataset.actorId;
-        const combatantActor = game.combat.data.combatants.find(combat => combat.data._id == c);
-        let damageTrack = combatantActor.actor.data.data.damage.damageTrack;
-        const combatantType = combatantActor.actor.data.type;
-        token = canvas.tokens.placeables.find(t => t.data.actorId == actor);
-        let dead = "icons/svg/skull.svg";
-        let effects = token.data.effects;
+      $('body').on('click', '.combatant-control', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const btn = event.currentTarget;
+        const li = btn.closest(".combatant");
+        const combatant = game.combat.combatants.get(li.dataset.combatantId);
 
         switch (btn.dataset.control) {
           // Toggle combatant visibility
           case "toggleHidden":
-            let hide = !token.data.hidden || false;
-            token.document.update({hidden: hide})
-              .then(() => {
-                combatantActor.actor.update({hidden: hide});
-              })
-            break;
-          // Mark damage track in PC sheet
-          case "markHale":
-              combatantActor.actor.update({ "data.damage.damageTrack": 'Hale' });
-              if (effects.includes(dead)) {
-                // console.log(effect)
-                token.toggleEffect(dead, {overlay:false});  
-              }
+            toggleHidden(combatant)
             break;
           case "markImpaired":
-              combatantActor.actor.update({ "data.damage.damageTrack": 'Impaired' });
-              if (effects.includes(dead)) {
-                // console.log(effect)
-                token.toggleEffect(dead, {overlay:false});  
-              }
+            if (combatant.actor.data.data.damage.damageTrack == "Impaired") {
+              combatant.actor.update({ "data.damage.damageTrack": 'Hale' })
+            } else {
+              combatant.actor.update({ "data.damage.damageTrack": 'Impaired' })
+            }
+            if (combatant.isDefeated) {
+              toggleDefeatedStatus(combatant);
+            }
             break;
           case "markDebilitated":
-              combatantActor.actor.update({ "data.damage.damageTrack": 'Debilitated' });
-              if (effects.includes(dead)) {
-                // console.log(effect)
-                token.toggleEffect(dead, {overlay:false});  
-              }
+            if (combatant.actor.data.data.damage.damageTrack == "Debilitated") {
+              combatant.actor.update({ "data.damage.damageTrack": 'Hale' })
+            } else {
+              combatant.actor.update({ "data.damage.damageTrack": 'Debilitated' })
+            }
+            if (combatant.isDefeated) {
+              toggleDefeatedStatus(combatant);
+            }
             break;
           case "markDead":
-            if (combatantType == 'PC') {
-              combatantActor.actor.update({ "data.damage.damageTrack": 'Dead' })
-                  if (!effects.includes(dead)) {
-                    // console.log(damageTrack, effects)
-                    token.toggleEffect(dead, {overlay:false});  
-                  } 
-            } else {
-                token.toggleEffect(dead, {overlay:false});  
+            if (combatant.actor.type == 'PC') {
+              if (combatant.actor.data.data.damage.damageTrack == "Dead") {
+                combatant.actor.update({ "data.damage.damageTrack": 'Hale' })
+              } else {
+                combatant.actor.update({ "data.damage.damageTrack": 'Dead' })
+              }
             }
-            break;  
+            toggleDefeatedStatus(combatant);
+            break;
           // Roll combatant initiative
           case "rollInitiative":
-            game.combat.rollInitiative([c]);
-            break;
+            return game.combat.rollInitiative([combatant.id]);
         }
       })
     });
@@ -228,7 +215,6 @@ export class CypherCombatSidebar {
         let content = await renderTemplate(template, templateData)
         newHtml.find('#combat-tracker').remove();
         newHtml.find('#combat-round').after(content);
-
       }
     });
   }
@@ -236,85 +222,49 @@ export class CypherCombatSidebar {
   /*
     Retrieve a list of combatants for the current combat. Combatants will be sorted into groups by actor type.
    */
-    getCombatantsData() {
-      // If there isn't a combat, exit and return an empty array.
-      if (!game.combat || !game.combat.data) {
-        return [];
-      }
-      
-      // Reduce the combatants array into a new object with keys based on the actor types.
-      let combatants = game.combat.data.combatants.filter((combatant) => {
-        // If this is for a combatant that has had its token/actor deleted, remove it from the combat.
-        if (!combatant.actor) {
-          game.combat.deleteEmbeddedDocuments('Combatant', [combatant.id]);
-        }
-        // Append valid actors to the appropriate group.
-        else {
-          // Initialize the group if it doesn't exist.
-          let type = combatant.actor.data.type;
-  
-          // Retrieve the health bars mode from the token's resource settings.
-          let displayBarsMode = Object.entries(CONST.TOKEN_DISPLAY_MODES).find(i => i[1] == combatant.token.data.displayBars)[0];
-          // Assume player characters should always show their health bar.
-          let displayStat = type == 'PC' ? true : false;
-  
-          // If this is a group other than character (such as NPC), we need to evaluate whether or not this player can see its health bar.
-          if (type != 'PC') {
-            // If the mode is one of the owner options, only the token owner or the GM should be able to see it.
-            if (displayBarsMode.includes("OWNER")) {
-              if (combatant.isOwner || game.user.isGM) {
-                displayStat = true;
-              }
-            }
-            // For other modes, always show it.
-            else if (displayBarsMode != "NONE") {
-              displayStat = true;
-            }
-            // If it's set to the none mode, hide it from players, but allow the GM to see it.
-            else {
-              displayStat = game.user.isGM ? true : false;
-            }
-  
-          }
-
-          // Establish PC's damage track
-          if (type == 'PC') {
-            let damageTrack = combatant.actor.data.data.damage.damageTrack;
-
-            combatant.dead = damageTrack == 'Dead';
-
-            combatant.debilitated = damageTrack == 'Debilitated';
-
-            combatant.impaired = damageTrack == 'Impaired';
-
-            combatant.hale = damageTrack == 'Hale';
-          }
-
-          if (type != 'PC') {
-            let dead = "icons/svg/skull.svg";
-            combatant.dead = combatant.token.data.effects.includes(dead);
-          }
-
-          // Determine if token is hidden
-          combatant.hid = combatant.token.data.hidden === true;
-
-          // Determine if combatant has rolled for initiative
-          combatant.hasRolled = combatant.initiative !== null;
-          // Set a property based on the health mode earlier.
-          combatant.displayStat = displayStat;
-          // Set a property for whether or not this is editable. This controls whether editabel fields like HP will be shown as an input or a div in the combat tracker HTML template.
-          combatant.editable = combatant.isOwner || game.user.isGM;
-  
-          return true;
-        }
-      });
-
-      // Sort the combatants by initiative.
-        combatants.sort((a, b) => {
-          return Number(b.initiative) - Number(a.initiative)
-        });   
-  
-      // Return the list of combatants.
-      return combatants;
+  getCombatantsData() {
+    // If there isn't a combat, exit and return an empty array.
+    if (!game.combat || !game.combat.data) {
+      return [];
     }
+
+    // Reduce the combatants array into a new object with keys based on the actor types.
+    let combatants = game.combat.data.combatants.filter((combatant) => {
+      // If this is for a combatant that has had its token/actor deleted, remove it from the combat.
+      if (!combatant.actor) {
+        game.combat.deleteEmbeddedDocuments('Combatant', [combatant.id]);
+      }
+      // Append valid actors to the appropriate group.
+      else {
+        // Initialize the group if it doesn't exist.
+        let type = combatant.actor.data.type;
+
+        // Establish PC's damage track
+        if (type == 'PC') {
+          let damageTrack = combatant.actor.data.data.damage.damageTrack;
+          combatant.dead = damageTrack == 'Dead';
+          combatant.debilitated = damageTrack == 'Debilitated';
+          combatant.impaired = damageTrack == 'Impaired';
+          combatant.hale = damageTrack == 'Hale';
+        }
+
+        // Determine if combatant has rolled for initiative
+        combatant.hasRolled = combatant.initiative !== null;
+
+        // Set a property for whether or not this is editable. This controls whether editabel fields like HP will be shown as an input or a div in the combat tracker HTML template.
+        combatant.isGM = game.user.isGM;
+        combatant.isObserver = (combatant.actor.permission == 2) ? true : false;
+
+        return true;
+      }
+    });
+
+    // Sort the combatants by initiative.
+    combatants.sort((a, b) => {
+      return Number(b.initiative) - Number(a.initiative)
+    });
+
+    // Return the list of combatants.
+    return combatants;
+  }
 }

--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -239,9 +239,13 @@ export class CypherCombatSidebar {
         }
         // Determine if combatant has rolled for initiative
         combatant.hasRolled = combatant.initiative !== null;
+
         // Set a property for whether or not this is editable. This controls whether editabel fields like HP will be shown as an input or a div in the combat tracker HTML template.
         combatant.isGM = game.user.isGM;
         combatant.isObserver = (combatant.actor.permission == 2) ? true : false;
+
+        // Determine if combatant is active
+        combatant.active = (combatant.data.actorId == game.combat.combatant.data.actorId) ? true : false;
       }
       // Append actors
       combatants.push(combatant)

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -3,47 +3,51 @@
 /* -------------------------------------------- */
 export class registerHelpers {
     static init() {
-        
-      Handlebars.registerHelper('concat', function() {
-          var outStr = '';
-          for (var arg in arguments) {
-            if (typeof arguments[arg] != 'object') {
-              outStr += arguments[arg];
+
+        Handlebars.registerHelper('concat', function () {
+            var outStr = '';
+            for (var arg in arguments) {
+                if (typeof arguments[arg] != 'object') {
+                    outStr += arguments[arg];
+                }
             }
-          }
-          return outStr;
+            return outStr;
         });
-    
-      Handlebars.registerHelper('toLowerCase', function(str) {
-          return str.toLowerCase();
+
+        Handlebars.registerHelper('toLowerCase', function (str) {
+            return str.toLowerCase();
         });
-  
-      Handlebars.registerHelper('ifCond', function (arg1, operator, arg2, options) {
-  
-          switch (operator) {
-              case '==':
-                  return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
-              case '===':
-                  return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
-              case '!=':
-                  return (arg1 != arg2) ? options.fn(this) : options.inverse(this);
-              case '!==':
-                  return (arg1 !== arg2) ? options.fn(this) : options.inverse(this);
-              case '<':
-                  return (arg1 < arg2) ? options.fn(this) : options.inverse(this);
-              case '<=':
-                  return (arg1 <= arg2) ? options.fn(this) : options.inverse(this);
-              case '>':
-                  return (arg1 > arg2) ? options.fn(this) : options.inverse(this);
-              case '>=':
-                  return (arg1 >= arg2) ? options.fn(this) : options.inverse(this);
-              case '&&':
-                  return (arg1 && arg2) ? options.fn(this) : options.inverse(this);
-              case '||':
-                  return (arg1 || arg2) ? options.fn(this) : options.inverse(this);
-              default:
-                  return options.inverse(this);
-          }
-      });
+
+        Handlebars.registerHelper('roundUp', function (int) {
+            return Math.ceil(int);
+        });
+
+        Handlebars.registerHelper('ifCond', function (arg1, operator, arg2, options) {
+
+            switch (operator) {
+                case '==':
+                    return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
+                case '===':
+                    return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
+                case '!=':
+                    return (arg1 != arg2) ? options.fn(this) : options.inverse(this);
+                case '!==':
+                    return (arg1 !== arg2) ? options.fn(this) : options.inverse(this);
+                case '<':
+                    return (arg1 < arg2) ? options.fn(this) : options.inverse(this);
+                case '<=':
+                    return (arg1 <= arg2) ? options.fn(this) : options.inverse(this);
+                case '>':
+                    return (arg1 > arg2) ? options.fn(this) : options.inverse(this);
+                case '>=':
+                    return (arg1 >= arg2) ? options.fn(this) : options.inverse(this);
+                case '&&':
+                    return (arg1 && arg2) ? options.fn(this) : options.inverse(this);
+                case '||':
+                    return (arg1 || arg2) ? options.fn(this) : options.inverse(this);
+                default:
+                    return options.inverse(this);
+            }
+        });
     }
-  }
+}

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -38,33 +38,5 @@ export class registerHelpers {
         Handlebars.registerHelper('log', function (object) {
             console.log(object);
         });
-
-        Handlebars.registerHelper('ifCond', function (arg1, operator, arg2, options) {
-
-            switch (operator) {
-                case '==':
-                    return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
-                case '===':
-                    return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
-                case '!=':
-                    return (arg1 != arg2) ? options.fn(this) : options.inverse(this);
-                case '!==':
-                    return (arg1 !== arg2) ? options.fn(this) : options.inverse(this);
-                case '<':
-                    return (arg1 < arg2) ? options.fn(this) : options.inverse(this);
-                case '<=':
-                    return (arg1 <= arg2) ? options.fn(this) : options.inverse(this);
-                case '>':
-                    return (arg1 > arg2) ? options.fn(this) : options.inverse(this);
-                case '>=':
-                    return (arg1 >= arg2) ? options.fn(this) : options.inverse(this);
-                case '&&':
-                    return (arg1 && arg2) ? options.fn(this) : options.inverse(this);
-                case '||':
-                    return (arg1 || arg2) ? options.fn(this) : options.inverse(this);
-                default:
-                    return options.inverse(this);
-            }
-        });
     }
 }

--- a/module/helpers/handlebars.mjs
+++ b/module/helpers/handlebars.mjs
@@ -22,6 +22,23 @@ export class registerHelpers {
             return Math.ceil(int);
         });
 
+        Handlebars.registerHelper('disposition', function (int) {
+            switch (int) {
+                case -1:
+                    return "hostile";
+                case 0:
+                    return "neutral";
+                case 1:
+                    return "friendly";
+                default:
+                    return "neutral";
+            }
+        });
+
+        Handlebars.registerHelper('log', function (object) {
+            console.log(object);
+        });
+
         Handlebars.registerHelper('ifCond', function (arg1, operator, arg2, options) {
 
             switch (operator) {

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -117,8 +117,15 @@
   align-self: center;
 }
 
+#combat-tracker .name-textbox {
+  height: 46px;
+  display: flex;
+  align-items: center;
+}
+
 #combat-tracker .truncate {
   line-height: 1;
+  margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -117,6 +117,16 @@
   align-self: center;
 }
 
+#combat-tracker .truncate {
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+          line-clamp: 2; 
+  -webkit-box-orient: vertical;
+}
+
 #combat-tracker .img-div {
   line-height: normal;
   text-align: center;

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -105,12 +105,17 @@
 
 #combat-tracker .combat-input input {
   color: white;
+  height: 20px;
+}
+
+#combat-tracker .combat-input input.hidden {
+  color: var(--color-text-light-7);
 }
 
 #combat-tracker .combat-input p {
-  height: 26px;
-  margin: 1px;
-  padding-top: 4px;
+  height: 20px;
+  margin: 0;
+  padding-top: 1px;
 }
 
 #combat-tracker li.combatant .token-name {
@@ -121,17 +126,6 @@
   height: 46px;
   display: flex;
   align-items: center;
-}
-
-#combat-tracker .truncate {
-  line-height: 1;
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-          line-clamp: 2; 
-  -webkit-box-orient: vertical;
 }
 
 #combat-tracker .img-div {
@@ -145,6 +139,10 @@
   margin: auto;
 }
 
+#combat-tracker li.combatant .roll.hidden {
+  filter: brightness(0.4);
+}
+
 #combat-tracker .combat-input label {
   font-size: 0.7rem;
 }
@@ -156,6 +154,40 @@
 #combat-tracker li.combatant .token-name .combatant-control {
   flex: 0 0 16px;
   padding: 1px;
+}
+
+#combat-tracker .combatant-controls {
+  height: 42px;
+  padding: 0;
+  vertical-align: bottom;
+  line-height: 1;
+}
+
+#combat-tracker .combatant-buttons {
+  color: var(--color-text-dark-5);
+  text-align: left;
+  line-height: 1.3;
+  padding-top: 0;
+  padding-bottom: 3px;
+  max-width: 49px;
+  width: 49px;
+}
+
+#combat-tracker .combatant-buttons.pc {
+  max-width: 98px;
+  width: 98px;
+}
+
+#combat-tracker .combatant-buttons .active {
+  color: var(--color-text-light-1);
+}
+
+#combat-tracker .combatant-values {
+  text-align: center;
+  text-align: -webkit-center;
+  padding-top: 0;
+  max-width: 49px;
+  width: 49px;
 }
 
 #combat-tracker .combatant {
@@ -185,4 +217,36 @@
   height: 22px;
   margin: auto;
   display: inline-block;
+}
+
+#combat-tracker .combat-table {
+  border: none;
+  background: none;
+  margin-bottom: 0;
+}
+
+#combat-tracker .combat-table .combatant-name {
+  width: 240px;
+}
+
+#combat-tracker .combat-table .combatant-name p {
+  width: 240px;
+  line-height: 1;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#combat-tracker .combat-table .truncate {
+  font-size: 0.7rem;
+  height: 16px;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+#combat-tracker table tr:nth-child(even) {
+  background: none;
 }

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -92,6 +92,10 @@
   grid-template-rows: repeat(2, minmax(0, 1fr));
 }
 
+#combat li.combatant.active {
+  border-color: var(--color-border-highlight);
+}
+
 #combat li.combatant .token-image {
   height: auto;
   width: auto;
@@ -200,27 +204,27 @@
 }
 
 #combat-tracker .PC {
-  background: rgb(52, 188, 78, 0.2);
-  border-top: 2px solid rgb(52, 188, 78, 1);
-  border-bottom: 2px solid rgb(52, 188, 78, 1);
+  background: rgb(52, 188, 78, 0.1);
+  border-top: 2px solid rgb(52, 188, 78, 0.3);
+  border-bottom: 2px solid rgb(52, 188, 78, 0.3);
 }
 
 #combat-tracker .hostile {
-  background: rgb(231, 33, 36, 0.2);
-  border-top: 2px solid rgb(231, 33, 36, 1);
-  border-bottom: 2px solid rgb(231, 33, 36, 1);
+  background: rgb(231, 33, 36, 0.1);
+  border-top: 2px solid rgb(231, 33, 36, 0.3);
+  border-bottom: 2px solid rgb(231, 33, 36, 0.3);
 }
 
 #combat-tracker .neutral {
-  background: rgb(241, 216, 53, 0.15);
-  border-top: 2px solid rgb(241, 216, 53, 1);
-  border-bottom: 2px solid rgb(241, 216, 53, 1);
+  background: rgb(241, 216, 53, 0.1);
+  border-top: 2px solid rgb(241, 216, 53, 0.3);
+  border-bottom: 2px solid rgb(241, 216, 53, 0.3);
 }
 
 #combat-tracker .friendly {
-  background: rgb(67, 223, 223, 0.2);
-  border-top: 2px solid rgb(67, 223, 223, 1);
-  border-bottom: 2px solid rgb(67, 223, 223, 1);
+  background: rgb(67, 223, 223, 0.1);
+  border-top: 2px solid rgb(67, 223, 223, 0.3);
+  border-bottom: 2px solid rgb(67, 223, 223, 0.3);
 }
 
 #combat-tracker span.initiative {

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -97,6 +97,10 @@
   width: auto;
 }
 
+#combat-tracker .defeated {
+  color: #b32019;
+}
+
 #combat-tracker .combat-input {
   line-height: normal;
   align-self: center;
@@ -236,6 +240,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-shadow: 1px 1px 4px var(--color-shadow-dark);
 }
 
 #combat-tracker .combat-table .truncate {

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -92,6 +92,11 @@
   grid-template-rows: repeat(2, minmax(0, 1fr));
 }
 
+#combat li.combatant .token-image {
+  height: auto;
+  width: auto;
+}
+
 #combat-tracker .combat-input {
   line-height: normal;
   align-self: center;
@@ -145,7 +150,7 @@
 }
 
 #combat-tracker span.initiative {
-  border: 1px dotted;
+  border: none;
   padding: 1.5px 3px;
   background-size: 22px;
   height: 22px;

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -138,9 +138,10 @@
 }
 
 #combat-tracker li.combatant .roll {
-  background-size: 22px;
-  height: 22px;
+  background-size: 20px;
+  height: 20px;
   margin: auto;
+  margin-bottom: 2px;
 }
 
 #combat-tracker li.combatant .roll.hidden {
@@ -200,18 +201,26 @@
 
 #combat-tracker .PC {
   background: rgb(0, 0, 85, 0.2);
+  border-top: 2px solid rgb(0, 0, 85, 1);
+  border-bottom: 2px solid rgb(0, 0, 85, 1);
 }
 
 #combat-tracker .hostile {
   background: rgb(85, 0, 0, 0.2);
+  border-top: 2px solid rgb(85, 0, 0, 1);
+  border-bottom: 2px solid rgb(85, 0, 0, 1);
 }
 
 #combat-tracker .neutral {
   background: rgb(0, 0, 0, 0.15);
+  border-top: 2px solid rgb(0, 0, 0, 1);
+  border-bottom: 2px solid rgb(0, 0, 0, 1);
 }
 
 #combat-tracker .friendly {
   background: rgb(0, 85, 0, 0.2);
+  border-top: 2px solid rgb(0, 85, 0, 1);
+  border-bottom: 2px solid rgb(0, 85, 0, 1);
 }
 
 #combat-tracker span.initiative {

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -141,12 +141,24 @@
   padding: 1px;
 }
 
-#combat-tracker .PC {
-  background: rgb(1, 71, 138, 0.2);
+#combat-tracker .combatant {
+  padding: 1px;
 }
 
-#combat-tracker :is(.NPC, .Companion, .Community, .Vehicle, .Token) {
-  background: rgb(90, 9, 9, 0.2);
+#combat-tracker .PC {
+  background: rgb(0, 0, 85, 0.2);
+}
+
+#combat-tracker .hostile {
+  background: rgb(85, 0, 0, 0.2);
+}
+
+#combat-tracker .neutral {
+  background: rgb(0, 0, 0, 0.15);
+}
+
+#combat-tracker .friendly {
+  background: rgb(0, 85, 0, 0.2);
 }
 
 #combat-tracker span.initiative {

--- a/styles/cyphercombat.css
+++ b/styles/cyphercombat.css
@@ -200,27 +200,27 @@
 }
 
 #combat-tracker .PC {
-  background: rgb(0, 0, 85, 0.2);
-  border-top: 2px solid rgb(0, 0, 85, 1);
-  border-bottom: 2px solid rgb(0, 0, 85, 1);
+  background: rgb(52, 188, 78, 0.2);
+  border-top: 2px solid rgb(52, 188, 78, 1);
+  border-bottom: 2px solid rgb(52, 188, 78, 1);
 }
 
 #combat-tracker .hostile {
-  background: rgb(85, 0, 0, 0.2);
-  border-top: 2px solid rgb(85, 0, 0, 1);
-  border-bottom: 2px solid rgb(85, 0, 0, 1);
+  background: rgb(231, 33, 36, 0.2);
+  border-top: 2px solid rgb(231, 33, 36, 1);
+  border-bottom: 2px solid rgb(231, 33, 36, 1);
 }
 
 #combat-tracker .neutral {
-  background: rgb(0, 0, 0, 0.15);
-  border-top: 2px solid rgb(0, 0, 0, 1);
-  border-bottom: 2px solid rgb(0, 0, 0, 1);
+  background: rgb(241, 216, 53, 0.15);
+  border-top: 2px solid rgb(241, 216, 53, 1);
+  border-bottom: 2px solid rgb(241, 216, 53, 1);
 }
 
 #combat-tracker .friendly {
-  background: rgb(0, 85, 0, 0.2);
-  border-top: 2px solid rgb(0, 85, 0, 1);
-  border-bottom: 2px solid rgb(0, 85, 0, 1);
+  background: rgb(67, 223, 223, 0.2);
+  border-top: 2px solid rgb(67, 223, 223, 1);
+  border-bottom: 2px solid rgb(67, 223, 223, 1);
 }
 
 #combat-tracker span.initiative {

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -6,7 +6,12 @@
       <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
       <div class="token-initiative">
         {{#if c.hasRolled}}
+        {{#ifCond c.actor.data.type '==' "PC"}}
         <span class="initiative">{{roundUp c.initiative}}</span>
+        {{else}}
+        {{log c}}
+        <span class="initiative">{{c.actor.data.data.level}} ({{roundUp c.initiative}})</span>
+        {{/ifCond}}
         {{else if c.editable}}
         <a class="combatant-control roll" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
         {{/if}}
@@ -14,7 +19,7 @@
     </div>
     {{!-- Name. --}}
     <div class="token-name grid-span-4">
-      <h4>{{c.name}}</h4>
+      <p class="truncate">{{c.name}}</p>
       <div class="combatant-controls flexrow">
         {{#if c.editable}}
         <a class="combatant-control {{#if c.hid}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
@@ -83,15 +88,15 @@
       {{else}}???{{/if}}
     </div>
     <div class="grid-span-2 combat-input">
-      <label for="armor">Armor</label>
-      {{#if c.editable}}
-      <p>{{c.actor.data.data.armor}}</p>
-      {{else}}???{{/if}}
-    </div>
-    <div class="grid-span-2 combat-input">
       <label for="damage">Damage</label>
       {{#if c.editable}}
       <p>{{c.actor.data.data.damage}}</p>
+      {{else}}???{{/if}}
+    </div>
+    <div class="grid-span-2 combat-input">
+      <label for="armor">Armor</label>
+      {{#if c.editable}}
+      <p>{{c.actor.data.data.armor}}</p>
       {{else}}???{{/if}}
     </div>
     {{/ifCond}}

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -1,6 +1,6 @@
 <ol id="combat-tracker" class="directory-list combatants">
   {{#each combatants as |c|}}
-  <li class="combatant {{c.actor.data.type}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
+  <li class="combatant {{#ifCond c.actor.data.type '==' "PC"}}PC{{else}}{{disposition c.token.data.disposition}}{{/ifCond}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
     {{!-- Token image --}}
     <div class="grid-span-2 img-div">
       <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
@@ -22,10 +22,10 @@
         </a>
         {{#ifCond c.actor.data.type '==' "PC"}}
         <a class="combatant-control {{#if c.hale}}active{{/if}}" title="Hale" data-control="markHale">
-          <i class="fas fa-check-circle"></i>
+          <i class="fas fa-heart"></i>
         </a>
         <a class="combatant-control {{#if c.impaired}}active{{/if}}" title="Impaired" data-control="markImpaired">
-          <i class="fas fa-tired"></i>
+          <i class="fas fa-heartbeat"></i>
         </a>
         <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
           <i class="fas fa-user-injured"></i>

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -19,7 +19,7 @@
       <table class="combat-table">
         <tr>
           <td class="combatant-name" colspan="100">
-            <p>{{c.name}}</p>
+            <p class="{{#if (or c.isDefeated c.dead)}}defeated{{/if}}">{{c.name}}</p>
           </td>
         </tr>
         <tr class="combatant-controls">
@@ -81,7 +81,7 @@
             <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
               <i class="fas fa-eye-slash"></i>
             </a>
-            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+            <a class="combatant-control {{#if c.isDefeated}}active{{/if}}" title="Dead" data-control="markDead">
               <i class="fas fa-skull"></i>
             </a>
             {{/if}}
@@ -122,7 +122,7 @@
             <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
               <i class="fas fa-eye-slash"></i>
             </a>
-            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+            <a class="combatant-control {{#if c.isDefeated}}active{{/if}}" title="Dead" data-control="markDead">
               <i class="fas fa-skull"></i>
             </a>
             {{/if}}
@@ -171,7 +171,7 @@
             <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
               <i class="fas fa-eye-slash"></i>
             </a>
-            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+            <a class="combatant-control {{#if c.isDefeated}}active{{/if}}" title="Dead" data-control="markDead">
               <i class="fas fa-skull"></i>
             </a>
             {{/if}}

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -1,7 +1,7 @@
 <ol id="combat-tracker" class="directory-list combatants">
   {{#each combatants as |c|}}
   {{#if (or c.isOwner (eq c.hidden false))}}
-  <li class="combatant {{#if c.hidden}}hidden{{/if}} {{#if (eq c.actor.data.type "PC")}}PC{{else}}{{disposition c.token.data.disposition}}{{/if}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
+  <li class="combatant {{#if c.hidden}}hidden{{/if}} {{#if (eq c.actor.data.type "PC")}}PC{{else}}{{disposition c.token.data.disposition}}{{/if}} directory-item actor-elem grid grid-12col {{#if c.active}}active{{/if}}" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
     {{!-- Token image --}}
     <div class="grid-span-2 img-div">
       <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -7,7 +7,13 @@
       <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
       <div class="token-initiative">
         {{#if c.hasRolled}}
+        {{#if (eq c.actor.data.type "PC")}}
         <span class="initiative">{{roundUp c.initiative}}</span>
+        {{else if (or c.isGM c.isObserver)}}
+        <span class="initiative">{{#if (eq c.actor.data.type "Community")}}{{c.actor.data.data.rank}}{{else}}{{c.actor.data.data.level}}{{/if}} ({{roundUp c.initiative}})</span>
+        {{else}}
+        <span class="initiative">? (?)</span>
+        {{/if}}
         {{else if c.isOwner}}
         <a class="combatant-control roll {{#if c.hidden}}hidden{{/if}}" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
         {{else}}
@@ -38,7 +44,7 @@
             <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
               <i class="fas fa-user-injured"></i>
             </a>
-            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+            <a class="combatant-control {{#if c.isDefeated}}active{{/if}}" title="Dead" data-control="markDead">
               <i class="fas fa-skull"></i>
             </a>
             {{/if}}

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -1,100 +1,100 @@
 <ol id="combat-tracker" class="directory-list combatants">
   {{#each combatants as |c|}}
-        <li class="combatant {{c.actor.data.type}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
-          {{!-- Token image --}}
-          <div class="grid-span-2 img-div">
-              <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
-              <div class="token-initiative">
-                {{#if c.hasRolled}}
-                <span class="initiative">{{c.initiative}}</span>
-                {{else if c.editable}}
-                <a class="combatant-control roll" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
-                {{/if}}
-              </div>
-          </div>
-          {{!-- Name. --}}
-          <div class="token-name grid-span-4">
-              <h4>{{c.name}}</h4>
-              <div class="combatant-controls flexrow">
-                    {{#if c.editable}}
-                      <a class="combatant-control {{#if c.hid}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
-                          <i class="fas fa-eye-slash"></i>
-                      </a>
-                      {{#ifCond c.actor.data.type '==' "PC"}}
-                      <a class="combatant-control {{#if c.hale}}active{{/if}}" title="Hale" data-control="markHale">
-                        <i class="fas fa-check-circle"></i>
-                      </a>
-                      <a class="combatant-control {{#if c.impaired}}active{{/if}}" title="Impaired" data-control="markImpaired">
-                          <i class="fas fa-tired"></i>
-                      </a>                      
-                      <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
-                          <i class="fas fa-user-injured"></i>
-                      </a>
-                      {{/ifCond}}
-                      <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
-                          <i class="fas fa-skull"></i>
-                      </a>
-                    {{/if}}
-                </div>
-          </div>
-          {{!-- Health, editable by owner or GM --}}
-          {{#ifCond c.actor.data.type '==' "PC"}}
-          <div class="grid-span-2 combat-input">
-            <label for="might">Might</label>
-            {{#if c.displayStat}}
-              {{#if c.editable}}
-                <input id="might" class="combat-input" type="text" name="data.pools.might.value" value="{{c.actor.data.data.pools.might.value}}" data-dtype="Number">
-              {{else}}
-                <p>{{c.actor.data.data.pools.might.value}}</p>
-              {{/if}}
-            {{else}}???{{/if}}
-          </div>
-          <div class="grid-span-2 combat-input">
-            <label for="speed">Speed</label>
-            {{#if c.displayStat}}
-              {{#if c.editable}}            
-              <input id="speed" class="combat-input" type="text" name="data.pools.speed.value" value="{{c.actor.data.data.pools.speed.value}}" data-dtype="Number">
-              {{else}}
-                <p>{{c.actor.data.data.pools.speed.value}}</p>
-              {{/if}}
-            {{else}}???{{/if}}
-          </div>
-          <div class="grid-span-2 combat-input">           
-            <label for="intellect">Intellect</label>
-            {{#if c.displayStat}}
-            {{#if c.editable}}
-            <input id="intellect" class="combat-input" type="text" name="data.pools.intellect.value" value="{{c.actor.data.data.pools.intellect.value}}" data-dtype="Number">
-            {{else}}
-                <p>{{c.actor.data.data.pools.intellect.value}}</p>
-            {{/if}}
-            {{else}}???{{/if}}
-          </div>
-          {{/ifCond}}
-          {{!-- Render Armor and Damage for NPCs --}}
-          {{#ifCond c.actor.data.type '!=' "PC"}}
-          <div class="grid-span-2 combat-input">
-            {{#if c.displayStat}}
-              {{#if c.editable}}
-                <label for="health">Health</label>
-                <input id="health" class="combat-input" type="text" name="data.health.value" value="{{c.actor.data.data.health.value}}" data-dtype="Number">
-              {{else}}
-                <p>{{c.actor.data.data.health.value}}</p>
-              {{/if}}
-            {{else}}???{{/if}}
-          </div>          
-          <div class="grid-span-2 combat-input">
-            <label for="armor">Armor</label>
-            {{#if c.editable}}
-            <p>{{c.actor.data.data.armor}}</p>
-            {{else}}???{{/if}}
-          </div>
-          <div class="grid-span-2 combat-input">
-            <label for="damage">Damage</label>
-            {{#if c.editable}}            
-            <p>{{c.actor.data.data.damage}}</p>
-            {{else}}???{{/if}}
-          </div>
-          {{/ifCond}}
-        </li>
+  <li class="combatant {{c.actor.data.type}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
+    {{!-- Token image --}}
+    <div class="grid-span-2 img-div">
+      <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
+      <div class="token-initiative">
+        {{#if c.hasRolled}}
+        <span class="initiative">{{roundUp c.initiative}}</span>
+        {{else if c.editable}}
+        <a class="combatant-control roll" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
+        {{/if}}
+      </div>
+    </div>
+    {{!-- Name. --}}
+    <div class="token-name grid-span-4">
+      <h4>{{c.name}}</h4>
+      <div class="combatant-controls flexrow">
+        {{#if c.editable}}
+        <a class="combatant-control {{#if c.hid}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+          <i class="fas fa-eye-slash"></i>
+        </a>
+        {{#ifCond c.actor.data.type '==' "PC"}}
+        <a class="combatant-control {{#if c.hale}}active{{/if}}" title="Hale" data-control="markHale">
+          <i class="fas fa-check-circle"></i>
+        </a>
+        <a class="combatant-control {{#if c.impaired}}active{{/if}}" title="Impaired" data-control="markImpaired">
+          <i class="fas fa-tired"></i>
+        </a>
+        <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
+          <i class="fas fa-user-injured"></i>
+        </a>
+        {{/ifCond}}
+        <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+          <i class="fas fa-skull"></i>
+        </a>
+        {{/if}}
+      </div>
+    </div>
+    {{!-- Health, editable by owner or GM --}}
+    {{#ifCond c.actor.data.type '==' "PC"}}
+    <div class="grid-span-2 combat-input">
+      <label for="might">Might</label>
+      {{#if c.displayStat}}
+      {{#if c.editable}}
+      <input id="might" class="combat-input" type="text" name="data.pools.might.value" value="{{c.actor.data.data.pools.might.value}}" data-dtype="Number">
+      {{else}}
+      <p>{{c.actor.data.data.pools.might.value}}</p>
+      {{/if}}
+      {{else}}???{{/if}}
+    </div>
+    <div class="grid-span-2 combat-input">
+      <label for="speed">Speed</label>
+      {{#if c.displayStat}}
+      {{#if c.editable}}
+      <input id="speed" class="combat-input" type="text" name="data.pools.speed.value" value="{{c.actor.data.data.pools.speed.value}}" data-dtype="Number">
+      {{else}}
+      <p>{{c.actor.data.data.pools.speed.value}}</p>
+      {{/if}}
+      {{else}}???{{/if}}
+    </div>
+    <div class="grid-span-2 combat-input">
+      <label for="intellect">Intellect</label>
+      {{#if c.displayStat}}
+      {{#if c.editable}}
+      <input id="intellect" class="combat-input" type="text" name="data.pools.intellect.value" value="{{c.actor.data.data.pools.intellect.value}}" data-dtype="Number">
+      {{else}}
+      <p>{{c.actor.data.data.pools.intellect.value}}</p>
+      {{/if}}
+      {{else}}???{{/if}}
+    </div>
+    {{/ifCond}}
+    {{!-- Render Armor and Damage for NPCs --}}
+    {{#ifCond c.actor.data.type '!=' "PC"}}
+    <div class="grid-span-2 combat-input">
+      {{#if c.displayStat}}
+      {{#if c.editable}}
+      <label for="health">Health</label>
+      <input id="health" class="combat-input" type="text" name="data.health.value" value="{{c.actor.data.data.health.value}}" data-dtype="Number">
+      {{else}}
+      <p>{{c.actor.data.data.health.value}}</p>
+      {{/if}}
+      {{else}}???{{/if}}
+    </div>
+    <div class="grid-span-2 combat-input">
+      <label for="armor">Armor</label>
+      {{#if c.editable}}
+      <p>{{c.actor.data.data.armor}}</p>
+      {{else}}???{{/if}}
+    </div>
+    <div class="grid-span-2 combat-input">
+      <label for="damage">Damage</label>
+      {{#if c.editable}}
+      <p>{{c.actor.data.data.damage}}</p>
+      {{else}}???{{/if}}
+    </div>
+    {{/ifCond}}
+  </li>
   {{/each}}
 </ol>

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -1,107 +1,239 @@
 <ol id="combat-tracker" class="directory-list combatants">
   {{#each combatants as |c|}}
-  <li class="combatant {{#ifCond c.actor.data.type '==' "PC"}}PC{{else}}{{disposition c.token.data.disposition}}{{/ifCond}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
+  {{log c.isObserver}}
+  {{#if (or c.isOwner (eq c.hidden false))}}
+  <li class="combatant {{#if c.hidden}}hidden{{/if}} {{#if (eq c.actor.data.type "PC")}}PC{{else}}{{disposition c.token.data.disposition}}{{/if}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
     {{!-- Token image --}}
     <div class="grid-span-2 img-div">
       <img class="token-image" id="combat-img" src="{{c.actor.img}}" alt="Thumbnail image for {{c.name}}">
       <div class="token-initiative">
         {{#if c.hasRolled}}
-        {{#ifCond c.actor.data.type '==' "PC"}}
         <span class="initiative">{{roundUp c.initiative}}</span>
+        {{else if c.isOwner}}
+        <a class="combatant-control roll {{#if c.hidden}}hidden{{/if}}" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
         {{else}}
-        {{log c}}
-        <span class="initiative">{{c.actor.data.data.level}} ({{roundUp c.initiative}})</span>
-        {{/ifCond}}
-        {{else if c.editable}}
-        <a class="combatant-control roll" title="{{localize 'COMBAT.InitiativeRoll'}}" data-control="rollInitiative"></a>
+        <span class="initiative">?</span>
         {{/if}}
       </div>
     </div>
-    {{!-- Name. --}}
-    <div class="token-name grid-span-4">
-      <div class="name-textbox">
-        <p class="truncate">{{c.name}}</p>
-      </div>
-      <div class="combatant-controls flexrow">
-        {{#if c.editable}}
-        <a class="combatant-control {{#if c.hid}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
-          <i class="fas fa-eye-slash"></i>
-        </a>
-        {{#ifCond c.actor.data.type '==' "PC"}}
-        <a class="combatant-control {{#if c.hale}}active{{/if}}" title="Hale" data-control="markHale">
-          <i class="fas fa-heart"></i>
-        </a>
-        <a class="combatant-control {{#if c.impaired}}active{{/if}}" title="Impaired" data-control="markImpaired">
-          <i class="fas fa-heartbeat"></i>
-        </a>
-        <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
-          <i class="fas fa-user-injured"></i>
-        </a>
-        {{/ifCond}}
-        <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
-          <i class="fas fa-skull"></i>
-        </a>
-        {{/if}}
-      </div>
+    <div class="grid-span-10">
+      <table class="combat-table">
+        <tr>
+          <td class="combatant-name" colspan="100">
+            <p>{{c.name}}</p>
+          </td>
+        </tr>
+        <tr class="combatant-controls">
+          {{!-- PCs --}}
+          {{#if (eq c.actor.data.type "PC")}}
+          <td class="combatant-buttons pc">
+            {{#if c.isGM}}
+            <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+              <i class="fas fa-eye-slash"></i>
+            </a>
+            {{/if}}
+            {{#if c.isOwner}}
+            <a class="combatant-control {{#if c.impaired}}active{{/if}}" title="Impaired" data-control="markImpaired">
+              <i class="fas fa-heartbeat"></i>
+            </a>
+            <a class="combatant-control {{#if c.debilitated}}active{{/if}}" title="Debilitated" data-control="markDebilitated">
+              <i class="fas fa-user-injured"></i>
+            </a>
+            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+              <i class="fas fa-skull"></i>
+            </a>
+            {{/if}}
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Might</p>
+              {{#if c.isOwner}}
+              <input id="might" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.pools.might.value" value="{{c.actor.data.data.pools.might.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.pools.might.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Speed</p>
+              {{#if c.isOwner}}
+              <input id="speed" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.pools.speed.value" value="{{c.actor.data.data.pools.speed.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.pools.speed.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Intellect</p>
+              {{#if c.isOwner}}
+              <input id="intellect" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.pools.intellect.value" value="{{c.actor.data.data.pools.intellect.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.pools.intellect.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          {{/if}}
+          {{!-- NPCs & Companions --}}
+          {{#if (or (eq c.actor.data.type "NPC") (eq c.actor.data.type "Companion"))}}
+          <td class="combatant-buttons">
+            {{#if c.isGM}}
+            <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+              <i class="fas fa-eye-slash"></i>
+            </a>
+            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+              <i class="fas fa-skull"></i>
+            </a>
+            {{/if}}
+          </td>
+          <td class="combatant-values">
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Health</p>
+              {{#if c.isOwner}}
+              <input id="health" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.health.value" value="{{c.actor.data.data.health.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.health.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Damage</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.damage}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Armor</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.armor}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          {{/if}}
+          {{!-- Communitees --}}
+          {{#if (eq c.actor.data.type "Community")}}
+          <td class="combatant-buttons">
+            {{#if c.isGM}}
+            <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+              <i class="fas fa-eye-slash"></i>
+            </a>
+            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+              <i class="fas fa-skull"></i>
+            </a>
+            {{/if}}
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Health</p>
+              {{#if c.isOwner}}
+              <input id="health" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.health.value" value="{{c.actor.data.data.health.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.health.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Infrastructure</p>
+              {{#if c.isOwner}}
+              <input id="infrastructure" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.infrastructure.value" value="{{c.actor.data.data.infrastructure.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.infrastructure.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Damage</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.damage}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Armor</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.armor}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          {{/if}}
+          {{!-- Vehicles --}}
+          {{#if (eq c.actor.data.type "Vehicle")}}
+          <td class="combatant-buttons">
+            {{#if c.isGM}}
+            <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+              <i class="fas fa-eye-slash"></i>
+            </a>
+            <a class="combatant-control {{#if c.dead}}active{{/if}}" title="Dead" data-control="markDead">
+              <i class="fas fa-skull"></i>
+            </a>
+            {{/if}}
+          </td>
+          <td class="combatant-values">
+          </td>
+          <td class="combatant-values">
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Crew</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.crew}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Weapons</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.weaponSystems}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          {{/if}}
+          {{!-- Marker --}}
+          {{#if (eq c.actor.data.type "Token")}}
+          <td class="combatant-buttons">
+            {{#if c.isGM}}
+            <a class="combatant-control {{#if c.hidden}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">
+              <i class="fas fa-eye-slash"></i>
+            </a>
+            {{/if}}
+          </td>
+          <td class="combatant-values">
+          </td>
+          <td class="combatant-values">
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Quantity</p>
+              {{#if c.isOwner}}
+              <input id="quantity" class="combat-input {{#if c.hidden}}hidden{{/if}}" type="text" name="data.quantity.value" value="{{c.actor.data.data.quantity.value}}" data-dtype="Number">
+              {{else if c.isObserver}}
+              <p>{{c.actor.data.data.quantity.value}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          <td class="combatant-values">
+            <div class="combat-input">
+              <p class="truncate">Max</p>
+              {{#if (or c.isOwner c.isObserver)}}
+              <p>{{c.actor.data.data.quantity.max}}</p>
+              {{else}}<p>?</p>{{/if}}
+            </div>
+          </td>
+          {{/if}}
+        </tr>
+      </table>
     </div>
-    {{!-- Health, editable by owner or GM --}}
-    {{#ifCond c.actor.data.type '==' "PC"}}
-    <div class="grid-span-2 combat-input">
-      <label for="might">Might</label>
-      {{#if c.displayStat}}
-      {{#if c.editable}}
-      <input id="might" class="combat-input" type="text" name="data.pools.might.value" value="{{c.actor.data.data.pools.might.value}}" data-dtype="Number">
-      {{else}}
-      <p>{{c.actor.data.data.pools.might.value}}</p>
-      {{/if}}
-      {{else}}???{{/if}}
-    </div>
-    <div class="grid-span-2 combat-input">
-      <label for="speed">Speed</label>
-      {{#if c.displayStat}}
-      {{#if c.editable}}
-      <input id="speed" class="combat-input" type="text" name="data.pools.speed.value" value="{{c.actor.data.data.pools.speed.value}}" data-dtype="Number">
-      {{else}}
-      <p>{{c.actor.data.data.pools.speed.value}}</p>
-      {{/if}}
-      {{else}}???{{/if}}
-    </div>
-    <div class="grid-span-2 combat-input">
-      <label for="intellect">Intellect</label>
-      {{#if c.displayStat}}
-      {{#if c.editable}}
-      <input id="intellect" class="combat-input" type="text" name="data.pools.intellect.value" value="{{c.actor.data.data.pools.intellect.value}}" data-dtype="Number">
-      {{else}}
-      <p>{{c.actor.data.data.pools.intellect.value}}</p>
-      {{/if}}
-      {{else}}???{{/if}}
-    </div>
-    {{/ifCond}}
-    {{!-- Render Armor and Damage for NPCs --}}
-    {{#ifCond c.actor.data.type '!=' "PC"}}
-    <div class="grid-span-2 combat-input">
-      {{#if c.displayStat}}
-      {{#if c.editable}}
-      <label for="health">Health</label>
-      <input id="health" class="combat-input" type="text" name="data.health.value" value="{{c.actor.data.data.health.value}}" data-dtype="Number">
-      {{else}}
-      <p>{{c.actor.data.data.health.value}}</p>
-      {{/if}}
-      {{else}}???{{/if}}
-    </div>
-    <div class="grid-span-2 combat-input">
-      <label for="damage">Damage</label>
-      {{#if c.editable}}
-      <p>{{c.actor.data.data.damage}}</p>
-      {{else}}???{{/if}}
-    </div>
-    <div class="grid-span-2 combat-input">
-      <label for="armor">Armor</label>
-      {{#if c.editable}}
-      <p>{{c.actor.data.data.armor}}</p>
-      {{else}}???{{/if}}
-    </div>
-    {{/ifCond}}
   </li>
+  {{/if}}
   {{/each}}
 </ol>

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -19,7 +19,9 @@
     </div>
     {{!-- Name. --}}
     <div class="token-name grid-span-4">
-      <p class="truncate">{{c.name}}</p>
+      <div class="name-textbox">
+        <p class="truncate">{{c.name}}</p>
+      </div>
       <div class="combatant-controls flexrow">
         {{#if c.editable}}
         <a class="combatant-control {{#if c.hid}}active{{/if}}" title="{{localize 'COMBAT.ToggleVis'}}" data-control="toggleHidden">

--- a/templates/combat.hbs
+++ b/templates/combat.hbs
@@ -1,6 +1,5 @@
 <ol id="combat-tracker" class="directory-list combatants">
   {{#each combatants as |c|}}
-  {{log c.isObserver}}
   {{#if (or c.isOwner (eq c.hidden false))}}
   <li class="combatant {{#if c.hidden}}hidden{{/if}} {{#if (eq c.actor.data.type "PC")}}PC{{else}}{{disposition c.token.data.disposition}}{{/if}} directory-item actor-elem grid grid-12col" data-actor-id="{{c.actor.data._id}}" data-token-id="{{c.tokenId}}" data-combatant-id="{{this.id}}" data-actor-type="{{c.actor.data.type}}">
     {{!-- Token image --}}


### PR DESCRIPTION
- Changed the layout of combatants to a table so that the name can take the whole line.
- The color of the combatants is determined by the token disposition (with the exceptions of PCs, which remain blue).
- The hidden status is reverted to default Foundry behavior. This hides the combatant in the combat tracker, not the token. I think those should remain separate.
- The dead status uses `isDefeated` for all token types. I’ll sync that up in the system, as that would be useful even if on doesn’t use your module.
- Whether the values can be seen is based on the actor permission instead of the visibilities of bars, as I assume most use Bar Brawl for that. Limited cannot see the values at all (just like having no permission at all). Observer can see, but not edit. Owner and GM can see and edit.