### PR TITLE
Update combat.mjs

### DIFF
--- a/module/helpers/combat.mjs
+++ b/module/helpers/combat.mjs
@@ -267,7 +267,7 @@ export class CypherCombatSidebar {
 
         // Set a property for whether or not this is editable. This controls whether editabel fields like HP will be shown as an input or a div in the combat tracker HTML template.
         combatant.isGM = game.user.isGM;
-        combatant.isObserver = (combatant.actor.permission == CONST.DOCUMENT_PERMISSION_LEVELS.OBSERVER) ? true : false;
+        combatant.isObserver = (combatant.actor.permission == CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER) ? true : false;
 
         // Determine if combatant is active
         combatant.active = (game.combat.started && combatant.tokenId == game.combat.combatant.tokenId) ? true : false;


### PR DESCRIPTION
V13 changed the structure of the global CONST object, renaming the DOCUMENT_PERMISSION_LEVELS enum to DOCUMENT_OWNERSHIP_LEVELS. This PR corrects the reference to that enum property to correctly locate and use it.
